### PR TITLE
Allow for spells with spaces

### DIFF
--- a/commands/cast.js
+++ b/commands/cast.js
@@ -10,7 +10,8 @@ module.exports = {
       return Broadcast.sayAt(player, "Casting spells must be surrounded in quotes e.g., cast 'fireball' target");
     }
 
-    const [ , , spellName, targetArgs] = match;
+    const [ , , spellNameSpaced, targetArgs] = match;
+    const spellName = spellNameSpaced.replace(/\s/,'_');
     const spell = state.SpellManager.find(spellName);
 
     if (!spell) {


### PR DESCRIPTION
It takes user input with spaces for spell names, and replaces the spaces with underscores. So in order to create a spell with spaces in it's name, you name the spellfile with _'s instead of spaces. 

IE....'bubbas_butt_blaster.js' spell
 could be cast with
``` cast 'bubbas butt blaster' banker ```

Otherwise, it seems like you're unable to put spaces in your spell names because the spell object appears to be using the filename as the key for spell lookup.

*edit* ahh shit =) lol, it actually worked just fine, you just had to be able to create a file with spaces in it.  and the changes here would then block that way of doing it.  So basically I 'fixed' something that actually works just fine :P Don't mind this, maybe I can cancel it.