### PR TITLE
Fix: specifying a skill lag of zero is now used.

### DIFF
--- a/commands/cast.js
+++ b/commands/cast.js
@@ -22,6 +22,6 @@ module.exports = {
         player.emit('useAbility', spell, targetArgs);
       },
       label: `cast ${args}`,
-    }, spell.lag !== null ? spell.lag : (state.Config.get('skillLag') || 1000));
+    }, spell.lag !== undefined ? spell.lag : (state.Config.get('skillLag') || 1000));
   }
 };

--- a/commands/cast.js
+++ b/commands/cast.js
@@ -22,6 +22,6 @@ module.exports = {
         player.emit('useAbility', spell, targetArgs);
       },
       label: `cast ${args}`,
-    }, spell.lag || state.Config.get('skillLag') || 1000);
+    }, spell.lag !== null ? spell.lag : (state.Config.get('skillLag') || 1000));
   }
 };

--- a/skills/heal.js
+++ b/skills/heal.js
@@ -23,6 +23,7 @@ module.exports = {
     cost: energyCost,
   },
   cooldown: 10,
+  lag: 1000,
 
   run: state => function (args, player, target) {
     const heal = new Heal('health', getHeal(player), player, this);


### PR DESCRIPTION
Currently, when `cast` is performed, the skill/spell is queued with a lag value that is never zero, regardless of whether that lag is specified in the skill/spell or not.  This is because zero is falsy, and I'm sure you were just trying to avoid pulling in the default lag value, which is `null`.  The solution is to test whether the lag is currently `null`.

Additionally, there were no examples where lag was specified, which always resulted in using a default lag as found in Config.  So I gave `heal` a default lag value so that developers are mindful of it.